### PR TITLE
Fix bug in playlist extractor and cleanup turtle script

### DIFF
--- a/Python/TurtleSnowflakes/TurtleSnowflakes.py
+++ b/Python/TurtleSnowflakes/TurtleSnowflakes.py
@@ -21,7 +21,7 @@ def branch():
         pat.left(45)
     pat.right(90)
     pat.forward(90)
-    9999999999999
+    # End of branch drawing
 for i in range(8):
     branch()
     pat.left(45)

--- a/Python/YT-Playlist-Link-Extractor/YTPlaylistXtract.py
+++ b/Python/YT-Playlist-Link-Extractor/YTPlaylistXtract.py
@@ -1,5 +1,6 @@
 import yt_dlp
 import csv
+import datetime
 
 playlist_url = input("Enter the playlist URL: ").strip()
 


### PR DESCRIPTION
## Summary
- add missing `datetime` import
- fix stray line in Turtle Snowflakes example

## Testing
- `python -m py_compile Python/YT-Playlist-Link-Extractor/YTPlaylistXtract.py`
- `python -m py_compile Python/TurtleSnowflakes/TurtleSnowflakes.py`
- `python -m py_compile Python/PyVisuBasics/helloGuiWorld.py`
- `python -m py_compile Python/mdx-clean/mdx-clean.py`
- `bash -n AudioRecorder/smart-audio-recorder.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840740e5f388326930e1c30fc49baa3