### PR TITLE
Add LED Blinker example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This repository contains various small to medium-sized projects that I built usi
 
 ## Projects List
 
+Currently available examples:
+
 - [Audio Recorder](./AudioRecorder/README.md)
-- [Temperature Sensor](./temperature-sensor/README.md)
 - [LED Blinker](./led-blinker/README.md)
-- [Wi-Fi Priority Switcher](./wifi-priority-switcher/README.md)
-- [Bluetooth Audio Setup](./bluetooth-audio/README.md)
+
+More experiments will be added over time.
 
 
 ## Notes

--- a/led-blinker/README.md
+++ b/led-blinker/README.md
@@ -1,0 +1,28 @@
+# LED Blinker 💡
+
+A minimal Python script to learn basic GPIO control on Raspberry Pi.
+This project toggles an LED on and off every second using the `RPi.GPIO` library.
+
+## Wiring
+
+1. Connect a 330Ω resistor to GPIO17 (pin 11 on the header).
+2. Attach an LED between the resistor and a ground pin (pin 6).
+
+![Wiring Diagram](https://i.imgur.com/qr2gYxG.png)
+
+## Usage
+
+```bash
+python3 blink.py
+```
+
+Stop with `Ctrl+C` and the script will clean up the GPIO state.
+
+## Requirements
+
+- Raspberry Pi OS
+- `RPi.GPIO` library (`sudo apt install python3-rpi.gpio`)
+
+## License
+
+MIT License – feel free to modify and share.

--- a/led-blinker/blink.py
+++ b/led-blinker/blink.py
@@ -1,0 +1,20 @@
+import RPi.GPIO as GPIO
+import time
+
+LED_PIN = 17  # You can change this to the GPIO pin you want to use
+
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(LED_PIN, GPIO.OUT)
+
+print("Blinking on GPIO", LED_PIN)
+
+try:
+    while True:
+        GPIO.output(LED_PIN, GPIO.HIGH)
+        time.sleep(1)
+        GPIO.output(LED_PIN, GPIO.LOW)
+        time.sleep(1)
+except KeyboardInterrupt:
+    print("\nExiting...")
+finally:
+    GPIO.cleanup()


### PR DESCRIPTION
## Summary
- add a simple LED blinker project
- ignore Python cache files
- update README with the new project list

## Testing
- `python3 -m py_compile led-blinker/blink.py`


------
https://chatgpt.com/codex/tasks/task_e_684079fd602c8326906815a4465d1ca1